### PR TITLE
Update shebang for greater compatibility

### DIFF
--- a/andrewsscript.sh
+++ b/andrewsscript.sh
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 echo "* * * * *  /bin/bash -c \"mv /Users/$USER/Desktop/*.png /Users/$USER/Desktop/screenshots\"" >> /var/spool/cron/crontabs/$USER


### PR DESCRIPTION
# Problem

`bash` is not always stored at `/bin/bash`.  For instance, if you have installed bash via homebrew, it will be elsewhere:

```
$ which bash
/usr/local/bin/bash
```

# Solution

Call `env` to lookup where `bash` is located.